### PR TITLE
[Feature/SUP-23] 마스킹한 데이터의 원본을 볼 수 있는 권한과 기능 추가

### DIFF
--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+AWS_REGION=ap-northeast-2
+AWS_PROFILE=deali-sandbox
+
+
+
+ECR_REPO="964225094109.dkr.ecr.ap-northeast-2.amazonaws.com/deali-db-portal"
+
+# ecr login
+RESULT=$(aws ecr get-login-password --profile ${AWS_PROFILE} --region ${AWS_REGION} | docker login --username AWS --password-stdin 964225094109.dkr.ecr.ap-northeast-2.amazonaws.com)
+if [ "$RESULT" != "Login Succeeded" ]; then
+  echo "ECR에 로그인 실패 하였습니다. aws Key를 확인해 주세요. result=$RESULT"
+  exit 1
+fi
+
+LATEST_IMAGE_TAG=$(aws ecr describe-images --region ${AWS_REGION} --profile ${AWS_PROFILE} --output json --repository-name deali-db-portal --query 'sort_by(imageDetails,& imagePushedAt)[*].imageTags[0]' | jq '.[]' | tail -10)
+echo "최근 ECR 에 등록된 image 는 아래와 같습니다."
+printf '%s\n' "${LATEST_IMAGE_TAG[@]}"
+echo ""
+
+read -p "build 할 버전을 입력해 주세요: " image_version
+if [ -z "$image_version" ]; then
+  echo "image version 입력 오류!"
+  exit 1
+fi
+
+# set
+IMAGE="${ECR_REPO}:${image_version}"
+
+# build docker
+docker build --platform linux/amd64 -t $IMAGE .
+
+# push docker image
+docker push $IMAGE
+
+echo "SUCCESS!"

--- a/superset/config.py
+++ b/superset/config.py
@@ -239,7 +239,7 @@ SQLALCHEMY_ENCRYPTED_FIELD_TYPE_ADAPTER = (  # pylint: disable=invalid-name
 QUERY_SEARCH_LIMIT = 1000
 
 MASKING_COLUMN_LIST = ["phone"]
-CAN_VIEW_MASKED_DATA_ROLE = "Admin"
+CAN_VIEW_MASKED_DATA_ROLE = "can_view_masked_data"
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -239,7 +239,6 @@ SQLALCHEMY_ENCRYPTED_FIELD_TYPE_ADAPTER = (  # pylint: disable=invalid-name
 QUERY_SEARCH_LIMIT = 1000
 
 MASKING_COLUMN_LIST = ["phone"]
-CAN_VIEW_MASKED_DATA_ROLE = "can_view_masked_data"
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -238,8 +238,8 @@ SQLALCHEMY_ENCRYPTED_FIELD_TYPE_ADAPTER = (  # pylint: disable=invalid-name
 # The limit of queries fetched for query search
 QUERY_SEARCH_LIMIT = 1000
 
-MASKING_COLUMN_LIST = []
-
+MASKING_COLUMN_LIST = ["phone"]
+CAN_VIEW_MASKED_DATA_ROLE = "Admin"
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -86,6 +86,8 @@ if TYPE_CHECKING:
     from superset.sql_parse import Table
     from superset.viz import BaseViz
 
+from superset.config import CAN_VIEW_MASKED_DATA_ROLE
+
 logger = logging.getLogger(__name__)
 
 DATABASE_PERM_REGEX = re.compile(r"^\[.+\]\.\(id\:(?P<id>\d+)\)$")
@@ -847,9 +849,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         # Creating default roles
         self.set_role("Admin", self._is_admin_pvm, pvms)
-        self.set_role("Alpha", self._is_alpha_pvm, pvms)
-        self.set_role("Gamma", self._is_gamma_pvm, pvms)
+        # self.set_role("Alpha", self._is_alpha_pvm, pvms)
+        # self.set_role("Gamma", self._is_gamma_pvm, pvms)
         self.set_role("sql_lab", self._is_sql_lab_pvm, pvms)
+        self.add_role(CAN_VIEW_MASKED_DATA_ROLE, [])
 
         # Configure public role
         if current_app.config["PUBLIC_ROLE_LIKE"]:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -86,7 +86,6 @@ if TYPE_CHECKING:
     from superset.sql_parse import Table
     from superset.viz import BaseViz
 
-from superset.config import CAN_VIEW_MASKED_DATA_ROLE
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +155,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
     userstatschartview = None
     READ_ONLY_MODEL_VIEWS = {"Database", "DynamicPlugin"}
+    
+    CAN_VIEW_MASKED_DATA = "can_view_masked_data"
 
     USER_MODEL_VIEWS = {
         "RegisterUserModelView",
@@ -852,7 +853,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # self.set_role("Alpha", self._is_alpha_pvm, pvms)
         # self.set_role("Gamma", self._is_gamma_pvm, pvms)
         self.set_role("sql_lab", self._is_sql_lab_pvm, pvms)
-        self.add_role(CAN_VIEW_MASKED_DATA_ROLE, [])
+        self.add_role(self.CAN_VIEW_MASKED_DATA, [])
 
         # Configure public role
         if current_app.config["PUBLIC_ROLE_LIKE"]:

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -69,7 +69,7 @@ from superset.sqllab.utils import masking_in_dicionary_value
 from superset.utils.s3_logger import S3Handler
 import os
 from flask import g
-from superset.config import CAN_VIEW_MASKED_DATA_ROLE
+from superset.config import CAN_VIEW_MASKED_DATA
 
 config = app.config
 logger = logging.getLogger(__name__)
@@ -345,7 +345,7 @@ class SqlLabRestApi(BaseSupersetApi):
         rows = params.get("rows")
         result = SqlExecutionResultsCommand(key=key, rows=rows).run()
 
-        if security_manager.find_role(CAN_VIEW_MASKED_DATA_ROLE) not in g.user.roles:
+        if security_manager.find_role(CAN_VIEW_MASKED_DATA) not in g.user.roles:
           result["data"] = list(map(lambda item: masking_in_dicionary_value(item), result["data"]))
 
         # return the result without special encoding

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -69,7 +69,6 @@ from superset.sqllab.utils import masking_in_dicionary_value
 from superset.utils.s3_logger import S3Handler
 import os
 from flask import g
-from superset.config import CAN_VIEW_MASKED_DATA
 
 config = app.config
 logger = logging.getLogger(__name__)
@@ -345,7 +344,8 @@ class SqlLabRestApi(BaseSupersetApi):
         rows = params.get("rows")
         result = SqlExecutionResultsCommand(key=key, rows=rows).run()
 
-        if security_manager.find_role(CAN_VIEW_MASKED_DATA) not in g.user.roles:
+        
+        if security_manager.find_role(security_manager.CAN_VIEW_MASKED_DATA) not in g.user.roles:
           result["data"] = list(map(lambda item: masking_in_dicionary_value(item), result["data"]))
 
         # return the result without special encoding

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -25,7 +25,7 @@ from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from marshmallow import ValidationError
 
-from superset import app, is_feature_enabled
+from superset import app, is_feature_enabled, security_manager
 from superset.commands.sql_lab.estimate import QueryEstimationCommand
 from superset.commands.sql_lab.execute import CommandResult, ExecuteSqlCommand
 from superset.commands.sql_lab.export import SqlResultExportCommand
@@ -68,6 +68,8 @@ from superset.views.base_api import BaseSupersetApi, requires_json, statsd_metri
 from superset.sqllab.utils import masking_in_dicionary_value
 from superset.utils.s3_logger import S3Handler
 import os
+from flask import g
+from superset.config import CAN_VIEW_MASKED_DATA_ROLE
 
 config = app.config
 logger = logging.getLogger(__name__)
@@ -342,7 +344,10 @@ class SqlLabRestApi(BaseSupersetApi):
         key = params.get("key")
         rows = params.get("rows")
         result = SqlExecutionResultsCommand(key=key, rows=rows).run()
-        result["data"] = list(map(lambda item: masking_in_dicionary_value(item), result["data"]))
+
+        if security_manager.find_role(CAN_VIEW_MASKED_DATA_ROLE) not in g.user.roles:
+          result["data"] = list(map(lambda item: masking_in_dicionary_value(item), result["data"]))
+
         # return the result without special encoding
         return json_success(
             json.dumps(

--- a/superset/sqllab/sqllab_execution_context.py
+++ b/superset/sqllab/sqllab_execution_context.py
@@ -34,7 +34,6 @@ from superset.utils.dates import now_as_float
 from superset.views.utils import get_cta_schema_name
 from superset.sqllab.utils import masking_in_dicionary_value
 from flask import g 
-from superset.config import CAN_VIEW_MASKED_DATA
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import Database

--- a/superset/sqllab/sqllab_execution_context.py
+++ b/superset/sqllab/sqllab_execution_context.py
@@ -34,7 +34,7 @@ from superset.utils.dates import now_as_float
 from superset.views.utils import get_cta_schema_name
 from superset.sqllab.utils import masking_in_dicionary_value
 from flask import g 
-from superset.config import CAN_VIEW_MASKED_DATA_ROLE
+from superset.config import CAN_VIEW_MASKED_DATA
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import Database


### PR DESCRIPTION
- SupersetSecurityManager에 설정된 const value `CAN_VIEW_MASKED_DATA` 에 따라 role 생성
- 해당 role을 가진 유저의 쿼리는 마스킹하지 않도록 설정
